### PR TITLE
Fix math and memory management issues

### DIFF
--- a/src/graphics/camera.c
+++ b/src/graphics/camera.c
@@ -3,6 +3,7 @@
 #include "cglm/affine-pre.h"
 #include "cglm/io.h"
 #include "cglm/vec3.h"
+#include <math.h>
 
 camera_t create_camera(vec3 position, int width, int height, float speed, float sensitivity) {
   vec3 final_position;
@@ -122,7 +123,7 @@ void inputs(GLFWwindow *window, camera_t *cam) {
   glm_vec3_copy(cam->orientation, newOrientation);
   glm_vec3_rotate(newOrientation, glm_rad(-offsetX), cam->up);
 
-  if (abs(glm_vec3_angle(newOrientation, cam->up) - glm_rad(90.0f)) <= glm_rad(85.0f)) {
+  if (fabsf(glm_vec3_angle(newOrientation, cam->up) - glm_rad(90.0f)) <= glm_rad(85.0f)) {
     glm_vec3_copy(newOrientation, cam->orientation);
   }
   glm_vec3_rotate(cam->orientation, glm_rad(-offsetY), right);

--- a/src/vk_backend/vk_instance.c
+++ b/src/vk_backend/vk_instance.c
@@ -49,9 +49,11 @@ VkInstance create_vulkan_instance(const char **validationLayers, u32 validationL
 
     if (vkCreateInstance(&createInfo, NULL, &instance) != VK_SUCCESS) {
         NFATAL("Failed to create Vulkan instance.\n")
+        free(extensions);
         exit(EXIT_FAILURE);
     }
 
+    free(extensions);
     return instance;
 }
 


### PR DESCRIPTION
## Summary
- prevent integer `abs` call on float data in camera input
- free allocated extension list after creating Vulkan instance

## Testing
- `bash build.sh` *(fails: Could NOT find Vulkan)*

------
https://chatgpt.com/codex/tasks/task_e_68518569a324832d8ae74e4b53bc55d3